### PR TITLE
support passing random generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,16 @@ fn main() {
     let travel_log = TravelLog::rand();
 }
 
-fn always_has_sunroof() -> TravelLog {
+fn always_has_sunroof(_rng: &mut impl rand::Rng) -> TravelLog {
     TravelLog::Car { has_sunroof: true }
 }
 
-fn rand_boat_speed() -> u32 {
-    thread_rng().gen_range(5..50)
+fn rand_boat_speed(rng: &mut impl rand::Rng) -> u32 {
+    rng.gen_range(5..50)
 }
 
-fn rand_temp() -> f32 {
-   thread_rng().gen_range(-20.0..120.0)
+fn rand_temp(rng: &mut impl rand::Rng) -> f32 {
+   rng.gen_range(-20.0..120.0)
 }
 
 use rand::{thread_rng, Rng};

--- a/enum-derived-macro/src/lib.rs
+++ b/enum-derived-macro/src/lib.rs
@@ -11,9 +11,9 @@ use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(Rand, attributes(custom_rand, weight))]
 pub fn derive_rand(input: TokenStream) -> TokenStream {
-    let mut input = parse_macro_input!(input as DeriveInput);
+    let input = parse_macro_input!(input as DeriveInput);
 
-    rand::expand_derive_rand(&mut input).unwrap_or_else(to_compile_errors)
+    rand::expand_derive_rand(&input).unwrap_or_else(to_compile_errors)
 }
 
 fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro::TokenStream {

--- a/enum-derived/Cargo.toml
+++ b/enum-derived/Cargo.toml
@@ -19,7 +19,7 @@ path = "tests/rand-progress.rs"
 
 [dependencies]
 rand = "0.8.5"
-enum-derived-macro = "0.2.0"
+enum-derived-macro = { path = "../enum-derived-macro", version = "0.2.0" }
 
 [dev-dependencies]
 trybuild = { version = "1.0.49", features = ["diff"] }

--- a/enum-derived/README.md
+++ b/enum-derived/README.md
@@ -48,17 +48,17 @@ fn main() {
     let travel_log = TravelLog::rand();
 }
 
-# fn always_has_sunroof() -> TravelLog {
+# fn always_has_sunroof(_rng: &mut impl rand::Rng) -> TravelLog {
 #     TravelLog::Car { has_sunroof: true }
 # }
 #
-# fn rand_boat_speed() -> u32 {
-#     thread_rng().gen_range(5..50)
+# fn rand_boat_speed(rng: &mut impl rand::Rng) -> u32 {
+#     rng.gen_range(5..50)
 # }
-# 
-# fn rand_temp() -> f32 {
-#    thread_rng().gen_range(-20.0..120.0)
+#
+# fn rand_temp(rng: &mut impl rand::Rng) -> f32 {
+#    rng.gen_range(-20.0..120.0)
 # }
-# 
+#
 # use rand::{thread_rng, Rng};
  ```

--- a/enum-derived/crates-io.md
+++ b/enum-derived/crates-io.md
@@ -52,16 +52,16 @@ fn main() {
     let travel_log = TravelLog::rand();
 }
 
-fn always_has_sunroof() -> TravelLog {
+fn always_has_sunroof(_rng: &mut impl rand::Rng) -> TravelLog {
     TravelLog::Car { has_sunroof: true }
 }
 
-fn rand_boat_speed() -> u32 {
-    thread_rng().gen_range(5..50)
+fn rand_boat_speed(rng: &mut impl rand::Rng) -> u32 {
+    rng.gen_range(5..50)
 }
 
-fn rand_temp() -> f32 {
-   thread_rng().gen_range(-20.0..120.0)
+fn rand_temp(rng: &mut impl rand::Rng) -> f32 {
+   rng.gen_range(-20.0..120.0)
 }
 
 use rand::{thread_rng, Rng};

--- a/enum-derived/examples/rand-dna.rs
+++ b/enum-derived/examples/rand-dna.rs
@@ -5,7 +5,7 @@ use enum_derived::Rand;
 #[derive(Rand)]
 pub struct Hello(u8, #[custom_rand(is_rand)] bool);
 
-fn is_rand() -> bool {
+fn is_rand(_rng: &mut impl rand::Rng) -> bool {
     false
 }
 

--- a/enum-derived/src/lib.rs
+++ b/enum-derived/src/lib.rs
@@ -1,21 +1,35 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
-use rand::distributions::{Distribution, Standard};
+use rand::{
+    distributions::{Distribution, Standard},
+    thread_rng, Rng,
+};
 
 /// Derive [Rand] for any enum or struct
 pub use enum_derived_macro::Rand;
 
 /// Generate a random version of the implementor
 pub trait Rand {
-    fn rand() -> Self;
+    fn rand() -> Self
+    where
+        Self: std::marker::Sized,
+    {
+        Self::rand_ext(&mut thread_rng())
+    }
+
+    fn rand_ext<R: Rng>(rng: &mut R) -> Self;
 }
 
 impl<S> Rand for S
 where
     Standard: Distribution<S>,
 {
-    fn rand() -> S {
-        ::rand::random::<S>()
+    fn rand() -> Self {
+        thread_rng().gen()
+    }
+
+    fn rand_ext<R: Rng>(rng: &mut R) -> Self {
+        rng.gen()
     }
 }

--- a/enum-derived/src/lib.rs
+++ b/enum-derived/src/lib.rs
@@ -10,11 +10,8 @@ use rand::{
 pub use enum_derived_macro::Rand;
 
 /// Generate a random version of the implementor
-pub trait Rand {
-    fn rand() -> Self
-    where
-        Self: std::marker::Sized,
-    {
+pub trait Rand: Sized {
+    fn rand() -> Self {
         Self::rand_ext(&mut thread_rng())
     }
 

--- a/enum-derived/tests/rand/11-custom-rand-function.rs
+++ b/enum-derived/tests/rand/11-custom-rand-function.rs
@@ -5,12 +5,11 @@ use rand::{thread_rng, Rng};
 
 const MAX_AGE: u8 = 120;
 
-fn rand_float() -> RandomTypes {
+fn rand_float(_rng: &mut impl Rng) -> RandomTypes {
     RandomTypes::FloatingPoint(0.0, 0.0)
 }
 
-fn rand_age() -> RandomTypes {
-    let mut rng = thread_rng();
+fn rand_age(_rng: &mut impl Rng) -> RandomTypes {
     RandomTypes::Age(rng.gen_range(0..MAX_AGE))
 }
 

--- a/enum-derived/tests/rand/12-custom-weights.rs
+++ b/enum-derived/tests/rand/12-custom-weights.rs
@@ -14,7 +14,7 @@ pub enum RandomWeights {
     Two,
     #[weight(3)]
     Three,
-    #[custom_rand(|| RandomWeights::Four)]
+    #[custom_rand(|_rng| RandomWeights::Four)]
     #[weight(4)]
     Four,
 }

--- a/enum-derived/tests/rand/19-custom-rand-for-struct-with-named-fields.rs
+++ b/enum-derived/tests/rand/19-custom-rand-for-struct-with-named-fields.rs
@@ -9,7 +9,7 @@ pub struct Hello {
     is_rand: bool
 }
 
-fn is_rand() -> bool {
+fn is_rand(_rng: &mut impl rand::Rng) -> bool {
     false
 }
 

--- a/enum-derived/tests/rand/20-custom-rand-for-struct-with-unnamed-fields.rs
+++ b/enum-derived/tests/rand/20-custom-rand-for-struct-with-unnamed-fields.rs
@@ -9,7 +9,7 @@ pub struct Hello (
     bool
 );
 
-fn is_rand() -> bool {
+fn is_rand(_rng: &mut impl rand::Rng) -> bool {
     false
 }
 

--- a/enum-derived/tests/rand/21-custom-rand-for-enum-with-named-fields-field-level.rs
+++ b/enum-derived/tests/rand/21-custom-rand-for-enum-with-named-fields-field-level.rs
@@ -11,7 +11,7 @@ pub enum Messages {
     Bil,
 }
 
-fn stamped() -> bool {
+fn stamped(_rng: &mut impl rand::Rng) -> bool {
     true
 }
 


### PR DESCRIPTION
This PR introduced these changes:
- Added another public trait function `rand_ext<R: Rng>(rng: &mut R) -> Self`
- Make `Rand` derive from `Sized`, so that `rand` can fallback to `rand_ext`
- (breaking) Changed the expected signature of `custom_rand` from `rand()` to `rand(rng)`